### PR TITLE
Update sphinx onion packet format to new spec

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -28,15 +28,19 @@ func BenchmarkPathPacketConstruction(b *testing.B) {
 		sphinxPacket *OnionPacket
 	)
 
-	var hopPayloads [][]byte
+	var hopsData []HopData
 	for i := 0; i < len(route); i++ {
-		payload := bytes.Repeat([]byte{byte('A' + i)}, HopPayloadSize)
-		hopPayloads = append(hopPayloads, payload)
+		hopsData = append(hopsData, HopData{
+			Realm:         0x00,
+			ForwardAmount: uint32(i),
+			OutgoingCltv:  uint32(i),
+		})
+		copy(hopsData[i].NextAddress[:], bytes.Repeat([]byte{byte(i)}, 8))
 	}
 
 	d, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{'A'}, 32))
 	for i := 0; i < b.N; i++ {
-		sphinxPacket, err = NewOnionPacket(route, d, hopPayloads, nil)
+		sphinxPacket, err = NewOnionPacket(route, d, hopsData, nil)
 		if err != nil {
 			b.Fatalf("unable to create packet: %v", err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,12 @@ func main() {
 
 		var hopsData []sphinx.HopData
 		for i := 0; i < len(route); i++ {
-			hopsData = append(hopsData, sphinx.HopData{})
+			hopsData = append(hopsData, sphinx.HopData{
+				Realm:         0x00,
+				ForwardAmount: uint32(i),
+				OutgoingCltv:  uint32(i),
+			})
+			copy(hopsData[i].NextAddress[:], bytes.Repeat([]byte{byte(i)}, 8))
 		}
 
 		msg, err := sphinx.NewOnionPacket(route, sessionKey, hopsData, assocData)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,13 +40,12 @@ func main() {
 
 		sessionKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{'A'}, 32))
 
-		var hopPayloads [][]byte
+		var hopsData []sphinx.HopData
 		for i := 0; i < len(route); i++ {
-			payload := bytes.Repeat([]byte{'A'}, 20)
-			hopPayloads = append(hopPayloads, payload)
+			hopsData = append(hopsData, sphinx.HopData{})
 		}
 
-		msg, err := sphinx.NewOnionPacket(route, sessionKey, hopPayloads, assocData)
+		msg, err := sphinx.NewOnionPacket(route, sessionKey, hopsData, assocData)
 		if err != nil {
 			log.Fatalf("Error creating message: %v", err)
 		}


### PR DESCRIPTION
lightningnetwork/lightning-rfc#145 changes qulite a few things around, merging the routing info with the hoppayloads and generally simplifying some things. This is my attempt at implementing the changes for `lnd`. I also took the liberty of flattening the onionpacket, since it was just wrapping a single MixHeader anyway.

From outside the changes should be limited to passing `HopData` structs instead of binary `hoppayloads`. These also include the `short_channel_id` (in serialized form since I wanted to avoud having to import `lnd` for it), outgoing CLTV and the forwarded amount. Finally, the next hop is now identified with the `short_channel_id`.