### PR TITLE
Comment Spelling Corrections - lightning-onion

### DIFF
--- a/hornet.go
+++ b/hornet.go
@@ -21,7 +21,7 @@ const fSLength = 48
 //  * NOTE: this doesn't include adding R to the forwarding segment, and w/e esle
 
 // Hmmm since each uses diff key, just use AES-CTR with blank nonce, given key,
-// encrypt plaintext of all zeroes, this'll give us our len(plaintext) rand bytes.
+// encrypt plaintext of all zeros, this'll give us our len(plaintext) rand bytes.
 // PRG0 -> {0, 1}^k -> {0, 1}^r(c+k) or {0, 1}^1280  (assuming 20 hops, like rusty, but, is that too large? maybe, idk)
 // PRG1 -> {0, 1}^k -> {0, 1}^r(c+k) or {0, 1}^1280  (assuming 20 hops)
 // PRG2 -> {0, 1}^k -> {0, 1}^rc or {0, 1}^960 (assuming 20 hops, c=48)

--- a/obfuscation.go
+++ b/obfuscation.go
@@ -30,7 +30,7 @@ type OnionErrorEncrypter struct {
 	sharedSecret [sha256.Size]byte
 }
 
-// NewOnionErrorEncrypter creates new instance of the onion encryper backed by
+// NewOnionErrorEncrypter creates new instance of the onion encrypter backed by
 // the passed router, with encryption to be doing using the passed
 // ephemeralKey.
 func NewOnionErrorEncrypter(router *Router,

--- a/sphinx.go
+++ b/sphinx.go
@@ -573,7 +573,7 @@ func (p ProcessCode) String() string {
 
 // ProcessedPacket encapsulates the resulting state generated after processing
 // an OnionPacket. A processed packet communicates to the caller what action
-// shuold be taken after processing.
+// should be taken after processing.
 type ProcessedPacket struct {
 	// Action represents the action the caller should take after processing
 	// the packet.


### PR DESCRIPTION
This change is scoped to correcting spelling mistakes in comments only. 
Apologies if this PR is submitted abnormally, I'm new to GitHub today and learning the process. 