### PR TITLE
Obfuscator Serialization

### DIFF
--- a/obfuscation.go
+++ b/obfuscation.go
@@ -69,6 +69,18 @@ func (o *OnionErrorEncrypter) EncryptError(initial bool, data []byte) []byte {
 	return onionEncrypt(o.sharedSecret, data)
 }
 
+// Encode writes the encrypter's shared secret to the provided io.Writer.
+func (o *OnionErrorEncrypter) Encode(w io.Writer) error {
+	_, err := w.Write(o.sharedSecret[:])
+	return err
+}
+
+// Decode restores the encrypter's share secret from the provided io.Reader.
+func (o *OnionErrorEncrypter) Decode(r io.Reader) error {
+	_, err := io.ReadFull(r, o.sharedSecret[:])
+	return err
+}
+
 // Circuit is used encapsulate the data which is needed for data deobfuscation.
 type Circuit struct {
 	// SessionKey is the key which have been used during generation of the

--- a/obfuscation_test.go
+++ b/obfuscation_test.go
@@ -3,6 +3,7 @@ package sphinx
 import (
 	"bytes"
 	"encoding/hex"
+	"reflect"
 	"testing"
 
 	"github.com/roasbeef/btcd/btcec"
@@ -199,6 +200,21 @@ func TestOnionFailureSpecVector(t *testing.T) {
 		}
 		obfuscator := &OnionErrorEncrypter{
 			sharedSecret: sharedSecrets[len(sharedSecrets)-1-i],
+		}
+
+		var b bytes.Buffer
+		if err := obfuscator.Encode(&b); err != nil {
+			t.Fatalf("unable to encode obfuscator: %v", err)
+		}
+
+		obfuscator2 := &OnionErrorEncrypter{}
+		obfuscatorReader := bytes.NewReader(b.Bytes())
+		if err := obfuscator2.Decode(obfuscatorReader); err != nil {
+			t.Fatalf("unable to decode obfuscator: %v", err)
+		}
+
+		if !reflect.DeepEqual(obfuscator, obfuscator2) {
+			t.Fatalf("unable to reconstruct obfuscator: %v", err)
 		}
 
 		if !bytes.Equal(expectedSharedSecret, obfuscator.sharedSecret[:]) {


### PR DESCRIPTION
Adds simple Encode/Decode functionality to the OnionErrorEncrypter. This is intended to be a temporary solution for being able to persist the onion error encrypters until the batched processing changes have been fully integrated. In the future, we will provide support for writing the entire onion blob to disk and then reprocess the onion packet to retrieve the error encrypter.