### PR TITLE
Ensure ReplaySet is fully initialized before using it

### DIFF
--- a/decayedlog.go
+++ b/decayedlog.go
@@ -403,7 +403,7 @@ func (d *DecayedLog) PutBatch(b *Batch) (*ReplaySet, error) {
 		// idempotent.
 		replayBytes := batchReplayBkt.Get(b.id)
 		if replayBytes != nil {
-			replays = &ReplaySet{}
+			replays = NewReplaySet()
 			return replays.Decode(bytes.NewReader(replayBytes))
 		}
 


### PR DESCRIPTION
`ReplaySet` contains a map that must be initialized in order to avoid nil map panics. This change makes sure the constructor is used rather than the zero value.

[Reported](https://gist.github.com/MDrollette/6342db0b7232046a5e30e7b2d7648cb2) via [Slack](https://lightningcommunity.slack.com/archives/C9RDCG8KT/p1521762020000040)