### PR TITLE
multi: implement latest multi-frame EOB proposal 

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -28,15 +28,19 @@ func BenchmarkPathPacketConstruction(b *testing.B) {
 		}
 
 		hopData := HopData{
-			Realm:         [1]byte{0x00},
 			ForwardAmount: uint64(i),
 			OutgoingCltv:  uint32(i),
 		}
 		copy(hopData.NextAddress[:], bytes.Repeat([]byte{byte(i)}, 8))
 
+		hopPayload, err := NewHopPayload(0, &hopData, nil)
+		if err != nil {
+			b.Fatalf("unable to create new hop payload: %v", err)
+		}
+
 		route[i] = OnionHop{
-			NodePub: *privKey.PubKey(),
-			HopData: hopData,
+			NodePub:    *privKey.PubKey(),
+			HopPayload: hopPayload,
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -14,6 +15,61 @@ import (
 	sphinx "github.com/lightningnetwork/lightning-onion"
 )
 
+type OnionHopSpec struct {
+	Realm     int    `json:"realm"`
+	PublicKey string `json:"pubkey"`
+	Payload   string `json:"payload"`
+}
+
+type OnionSpec struct {
+	SessionKey string         `json:"session_key,omitempty"`
+	Hops       []OnionHopSpec `json:"hops"`
+}
+
+func parseOnionSpec(spec OnionSpec) (*sphinx.PaymentPath, *btcec.PrivateKey, error) {
+	var path sphinx.PaymentPath
+	var binSessionKey []byte
+	var err error
+
+	if spec.SessionKey != "" {
+		binSessionKey, err = hex.DecodeString(spec.SessionKey)
+		if err != nil {
+			log.Fatalf("Unable to decode the sessionKey %v: %v\n", spec.SessionKey, err)
+		}
+
+		if len(binSessionKey) != 32 {
+			log.Fatalf("Session key must be a 32 byte hex string: %v\n", spec.SessionKey)
+		}
+	} else {
+		binSessionKey = bytes.Repeat([]byte{'A'}, 32)
+	}
+
+	sessionKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), binSessionKey)
+
+	for i, hop := range spec.Hops {
+		binKey, err := hex.DecodeString(hop.PublicKey)
+		if err != nil || len(binKey) != 33 {
+			log.Fatalf("%s is not a valid hex pubkey %s", hop.PublicKey, err)
+		}
+
+		pubkey, err := btcec.ParsePubKey(binKey, btcec.S256())
+		if err != nil {
+			log.Fatalf("%s is not a valid hex pubkey %s", hop.PublicKey, err)
+		}
+
+		path[i].NodePub = *pubkey
+
+		path[i].HopPayload.Realm[0] = byte(hop.Realm)
+		path[i].HopPayload.Payload, err = hex.DecodeString(hop.Payload)
+		if err != nil {
+			log.Fatalf("%s is not a valid hex payload %s", hop.Payload, err)
+		}
+
+		fmt.Fprintf(os.Stderr, "Node %d pubkey %x\n", i, pubkey.SerializeCompressed())
+	}
+	return &path, sessionKey, nil
+}
+
 // main implements a simple command line utility that can be used in order to
 // either generate a fresh mix-header or decode and fully process an existing
 // one given a private key.
@@ -22,44 +78,33 @@ func main() {
 
 	assocData := bytes.Repeat([]byte{'B'}, 32)
 
-	if len(args) == 1 {
-		fmt.Printf("Usage: %s (generate|decode) <private-keys>\n", args[0])
+	if len(args) < 3 {
+		fmt.Printf("Usage: %s (generate|decode) <input-file>\n", args[0])
+		return
 	} else if args[1] == "generate" {
-		var path sphinx.PaymentPath
-		for i, hexKey := range args[2:] {
-			binKey, err := hex.DecodeString(hexKey)
-			if err != nil || len(binKey) != 33 {
-				log.Fatalf("%s is not a valid hex pubkey %s", hexKey, err)
-			}
+		var spec OnionSpec
 
-			pubkey, err := btcec.ParsePubKey(binKey, btcec.S256())
-			if err != nil {
-				panic(err)
-			}
-
-			path[i] = sphinx.OnionHop{
-				NodePub: *pubkey,
-				HopData: sphinx.HopData{
-					Realm:         [1]byte{0x00},
-					ForwardAmount: uint64(i),
-					OutgoingCltv:  uint32(i),
-				},
-			}
-			copy(path[i].HopData.NextAddress[:], bytes.Repeat([]byte{byte(i)}, 8))
-
-			fmt.Fprintf(os.Stderr, "Node %d pubkey %x\n", i, pubkey.SerializeCompressed())
+		jsonSpec, err := ioutil.ReadFile(args[2])
+		if err != nil {
+			log.Fatalf("Unable to read JSON onion spec from file %v: %v", args[2], err)
 		}
 
-		sessionKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bytes.Repeat([]byte{'A'}, 32))
+		if err := json.Unmarshal(jsonSpec, &spec); err != nil {
+			log.Fatalf("Unable to parse JSON onion spec: %v", err)
+		}
 
-		msg, err := sphinx.NewOnionPacket(&path, sessionKey, assocData)
+		path, sessionKey, err := parseOnionSpec(spec)
+		if err != nil {
+			log.Fatalf("could not parse onion spec: %v", err)
+		}
+
+		msg, err := sphinx.NewOnionPacket(path, sessionKey, assocData)
 		if err != nil {
 			log.Fatalf("Error creating message: %v", err)
 		}
 
 		w := bytes.NewBuffer([]byte{})
 		err = msg.Encode(w)
-
 		if err != nil {
 			log.Fatalf("Error serializing message: %v", err)
 		}
@@ -78,8 +123,11 @@ func main() {
 		}
 
 		privkey, _ := btcec.PrivKeyFromBytes(btcec.S256(), binKey)
-		s := sphinx.NewRouter(privkey, &chaincfg.TestNet3Params,
-			sphinx.NewMemoryReplayLog())
+		replay_log := sphinx.NewMemoryReplayLog()
+		s := sphinx.NewRouter(privkey, &chaincfg.TestNet3Params, replay_log)
+
+		replay_log.Start()
+		defer replay_log.Stop()
 
 		var packet sphinx.OnionPacket
 		err = packet.Decode(bytes.NewBuffer(binMsg))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,11 +59,20 @@ func parseOnionSpec(spec OnionSpec) (*sphinx.PaymentPath, *btcec.PrivateKey, err
 
 		path[i].NodePub = *pubkey
 
-		path[i].HopPayload.Realm[0] = byte(hop.Realm)
-		path[i].HopPayload.Payload, err = hex.DecodeString(hop.Payload)
+		payload, err := hex.DecodeString(hop.Payload)
 		if err != nil {
-			log.Fatalf("%s is not a valid hex payload %s", hop.Payload, err)
+			log.Fatalf("%s is not a valid hex payload %s",
+				hop.Payload, err)
 		}
+
+		hopPayload, err := sphinx.NewHopPayload(
+			byte(hop.Realm), nil, payload,
+		)
+		if err != nil {
+			log.Fatalf("unable to make payload: %v", err)
+		}
+
+		path[i].HopPayload = hopPayload
 
 		fmt.Fprintf(os.Stderr, "Node %d pubkey %x\n", i, pubkey.SerializeCompressed())
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,39 @@
+package sphinx
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestHopPayloadSizes(t *testing.T) {
+	var tests = []struct {
+		size     int
+		expected int
+		realm    byte
+	}{
+		{30, 1, 0x01},
+		{32, 1, 0x01},
+		{33, 2, 0x11},
+		{97, 2, 0x11}, // The largest possible 2-hop payload
+		{98, 3, 0x21},
+		{162, 3, 0x21},
+		{163, 4, 0x31},
+	}
+
+	for _, tt := range tests {
+		hp := HopPayload{
+			Realm:   [1]byte{1},
+			Payload: bytes.Repeat([]byte{0x00}, tt.size),
+		}
+
+		actual := hp.NumFrames()
+		if actual != tt.expected {
+			t.Errorf("Wrong number of hops returned: expected %d, actual %d", tt.expected, actual)
+		}
+
+		hp.CalculateRealm()
+		if hp.Realm[0] != tt.realm {
+			t.Errorf("Updated realm did not match our expectation: expected %q, actual %q", tt.realm, hp.Realm)
+		}
+	}
+}

--- a/path_test.go
+++ b/path_test.go
@@ -34,9 +34,10 @@ func TestHopPayloadSizes(t *testing.T) {
 				"%d, actual %d", tt.expected, actual)
 		}
 
-		hp.CalculateRealm()
-		if hp.Realm[0] != tt.realm {
-			t.Errorf("Updated realm did not match our expectation: expected %q, actual %q", tt.realm, hp.Realm)
+		if hp.payloadRealm() != tt.realm {
+			t.Errorf("payload realm did not match our "+
+				"expectation: expected %q, actual %q", tt.realm,
+				hp.Realm())
 		}
 	}
 }

--- a/path_test.go
+++ b/path_test.go
@@ -21,14 +21,17 @@ func TestHopPayloadSizes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		hp := HopPayload{
-			Realm:   [1]byte{1},
-			Payload: bytes.Repeat([]byte{0x00}, tt.size),
+		hp, err := NewHopPayload(
+			1, nil, bytes.Repeat([]byte{0x00}, tt.size),
+		)
+		if err != nil {
+			t.Fatalf("unable to make hop payload: %v", err)
 		}
 
 		actual := hp.NumFrames()
 		if actual != tt.expected {
-			t.Errorf("Wrong number of hops returned: expected %d, actual %d", tt.expected, actual)
+			t.Errorf("wrong number of hops returned: expected "+
+				"%d, actual %d", tt.expected, actual)
 		}
 
 		hp.CalculateRealm()

--- a/sphinx.go
+++ b/sphinx.go
@@ -443,10 +443,10 @@ type ProcessedPacket struct {
 	// MoreHops.
 	ForwardingInstructions *HopData
 
-	// RawPayload is the raw (plaintext) payload that was passed to the
-	// processing node in the onion packet. It provides accessors to get
-	// the parsed and interpreted data.
-	RawPayload HopPayload
+	// ExtraOnionBlob is the raw EOB payload unpacked by this hop. This is
+	// the portion of the payload _without_ the prefixed forwarding
+	// instructions.
+	ExtraOnionBlob []byte
 
 	// NextPacket is the onion packet that should be forwarded to the next
 	// hop as denoted by the ForwardingInstructions field.
@@ -454,6 +454,8 @@ type ProcessedPacket struct {
 	// NOTE: This field will only be populated iff the above Action is
 	// MoreHops.
 	NextPacket *OnionPacket
+
+	rawPayload HopPayload
 }
 
 // Router is an onion router within the Sphinx network. The router is capable
@@ -649,7 +651,7 @@ func processOnionPacket(onionPkt *OnionPacket, sharedSecret *Hash256,
 		action = ExitNode
 	}
 
-	hopData, err := outerHopPayload.HopData()
+	hopData, eob, err := outerHopPayload.HopData()
 	if err != nil {
 		return nil, err
 	}
@@ -660,8 +662,9 @@ func processOnionPacket(onionPkt *OnionPacket, sharedSecret *Hash256,
 	return &ProcessedPacket{
 		Action:                 action,
 		ForwardingInstructions: hopData,
-		RawPayload:             *outerHopPayload,
+		ExtraOnionBlob:         eob,
 		NextPacket:             innerPkt,
+		rawPayload:             *outerHopPayload,
 	}, nil
 }
 

--- a/sphinx.go
+++ b/sphinx.go
@@ -314,7 +314,9 @@ func NewOnionPacket(paymentPath *PaymentPath, sessionKey *btcec.PrivateKey,
 			return nil, err
 		}
 
-		paymentPath[i].HopPayload.Payload = hopDataBuf.Bytes()
+		paymentPath[i].HopPayload.Payload = append(
+			hopDataBuf.Bytes(), paymentPath[i].HopPayload.Payload...,
+		)
 
 		err = paymentPath[i].HopPayload.Encode(&hopPayloadBuf)
 		if err != nil {

--- a/sphinx.go
+++ b/sphinx.go
@@ -268,7 +268,6 @@ func NewOnionPacket(paymentPath *PaymentPath, sessionKey *btcec.PrivateKey,
 		packet := append(mixHeader[:], assocData...)
 		nextHmac = calcMac(muKey, packet)
 
-		hopDataBuf.Reset()
 		hopPayloadBuf.Reset()
 	}
 

--- a/sphinx_test.go
+++ b/sphinx_test.go
@@ -222,7 +222,7 @@ func TestSphinxCorrectness(t *testing.T) {
 		// The hop data for this hop should *exactly* match what was
 		// initially used to construct the packet.
 		expectedHopData := (*hopDatas)[i]
-		if !reflect.DeepEqual(onionPacket.ForwardingInstructions, expectedHopData) {
+		if !reflect.DeepEqual(*onionPacket.ForwardingInstructions, expectedHopData) {
 			t.Fatalf("hop data doesn't match: expected %v, got %v",
 				spew.Sdump(expectedHopData),
 				spew.Sdump(onionPacket.ForwardingInstructions))


### PR DESCRIPTION
This takes off where #31 and #33 left off. It implements the latest version of lightningnetwork/lightning-rfc#593 (4 bits right now, but I think that's heading to 3 bits for the packet type). At the same time with the way the code is implemented right now, it's a short distance away from lightningnetwork/lightning-rfc#604 if we end up going in that direction (only thing that would change in that case is the new `HopData` method and the `packRealm` method). 

This PR takes the commits from #33, implements a few bug fixes along the way, and the unifies the external caller API with that of #31. It passes all the tests from #31 as is, but I also plan to port over relevant tests from #33 as they exercise additional end-to-end behavior. 