### PR TITLE
sphinx: pad out the starting packet with random bytes

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -51,7 +51,9 @@ func BenchmarkPathPacketConstruction(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		sphinxPacket, err = NewOnionPacket(&route, d, nil)
+		sphinxPacket, err = NewOnionPacket(
+			&route, d, nil, BlankPacketFiller,
+		)
 		if err != nil {
 			b.Fatalf("unable to create packet: %v", err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,7 +105,10 @@ func main() {
 			log.Fatalf("could not parse onion spec: %v", err)
 		}
 
-		msg, err := sphinx.NewOnionPacket(path, sessionKey, assocData)
+		msg, err := sphinx.NewOnionPacket(
+			path, sessionKey, assocData,
+			sphinx.DeterministicPacketFiller,
+		)
 		if err != nil {
 			log.Fatalf("Error creating message: %v", err)
 		}

--- a/packetfiller.go
+++ b/packetfiller.go
@@ -1,0 +1,61 @@
+package sphinx
+
+import (
+	"crypto/rand"
+
+	"github.com/aead/chacha20"
+	"github.com/btcsuite/btcd/btcec"
+)
+
+// PacketFiller is a function type to be specified by the caller to provide a
+// stream of random bytes derived from a CSPRNG to fill out the starting packet
+// in order to ensure we don't leak information on the true route length to the
+// receiver. The packet filler may also use the session key to generate a set
+// of filler bytes if it wishes to be deterministic.
+type PacketFiller func(*btcec.PrivateKey, *[routingInfoSize]byte) error
+
+// RandPacketFiller is a packet filler that reads a set of random bytes from a
+// CSPRNG.
+func RandPacketFiller(_ *btcec.PrivateKey, mixHeader *[routingInfoSize]byte) error {
+	// Read out random bytes to fill out the rest of the starting packet
+	// after the hop payload for the final node. This mitigates a privacy
+	// leak that may reveal a lower bound on the true path length to the
+	// receiver.
+	if _, err := rand.Read(mixHeader[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BlankPacketFiller is a packet filler that doesn't attempt to fill out the
+// packet at all. It should ONLY be used for generating test vectors or other
+// instances that required deterministic packet generation.
+func BlankPacketFiller(_ *btcec.PrivateKey, _ *[routingInfoSize]byte) error {
+	return nil
+}
+
+// DeterministicPacketFiller is a packet filler that generates a deterministic
+// set of filler bytes by using chacha20 with a key derived from the session
+// key.
+func DeterministicPacketFiller(sessionKey *btcec.PrivateKey,
+	mixHeader *[routingInfoSize]byte) error {
+
+	// First, we'll generate a new key that'll be used to generate some
+	// random bytes for our padding purposes. To derive this new key, we
+	// essentially calculate: HMAC("pad", sessionKey).
+	var sessionKeyBytes Hash256
+	copy(sessionKeyBytes[:], sessionKey.Serialize())
+	paddingKey := generateKey("pad", &sessionKeyBytes)
+
+	// Now that we have our target key, we'll use chacha20 to generate a
+	// series of random bytes directly into the passed mixHeader packet.
+	var nonce [8]byte
+	padCipher, err := chacha20.NewCipher(nonce[:], paddingKey[:])
+	if err != nil {
+		return err
+	}
+	padCipher.XORKeyStream(mixHeader[:], mixHeader[:])
+
+	return nil
+}

--- a/sphinx_test.go
+++ b/sphinx_test.go
@@ -135,7 +135,9 @@ func newTestRoute(numHops int) ([]*Router, *PaymentPath, *[]HopData, *OnionPacke
 	sessionKey, _ := btcec.PrivKeyFromBytes(
 		btcec.S256(), bytes.Repeat([]byte{'A'}, 32),
 	)
-	fwdMsg, err := NewOnionPacket(&route, sessionKey, nil)
+	fwdMsg, err := NewOnionPacket(
+		&route, sessionKey, nil, DeterministicPacketFiller,
+	)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("unable to create "+
 			"forwarding message: %#v", err)
@@ -198,7 +200,7 @@ func TestBolt4Packet(t *testing.T) {
 	}
 
 	sessionKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), bolt4SessionKey)
-	pkt, err := NewOnionPacket(&route, sessionKey, bolt4AssocData)
+	pkt, err := NewOnionPacket(&route, sessionKey, bolt4AssocData, BlankPacketFiller)
 	if err != nil {
 		t.Fatalf("unable to construct onion packet: %v", err)
 	}
@@ -558,12 +560,14 @@ func newEOBRoute(numHops uint32,
 	}
 
 	// Generate a forwarding message to route to the final node via the
-	// generated intermdiates nodes above.  Destination should be Hash160,
+	// generated intermediate nodes above.  Destination should be Hash160,
 	// adding padding so parsing still works.
 	sessionKey, _ := btcec.PrivKeyFromBytes(
 		btcec.S256(), bytes.Repeat([]byte{'A'}, 32),
 	)
-	fwdMsg, err := NewOnionPacket(&route, sessionKey, nil)
+	fwdMsg, err := NewOnionPacket(
+		&route, sessionKey, nil, DeterministicPacketFiller,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -920,7 +924,9 @@ func TestVariablePayloadOnion(t *testing.T) {
 
 	// With all the required data assembled, we'll craft a new packet.
 	sessionKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), sessionKeyBytes)
-	pkt, err := NewOnionPacket(&route, sessionKey, associatedData)
+	pkt, err := NewOnionPacket(
+		&route, sessionKey, associatedData, BlankPacketFiller,
+	)
 	if err != nil {
 		t.Fatalf("unable to construct onion packet: %v", err)
 	}


### PR DESCRIPTION
   By padding out the starting packet with random bytes rather than leaving
   the zeroes in tact, we patch a privacy leak that may reveal a lower
    bound on the true route length to an adversarial exit node.

  In order to reconcile this with our existing set of test vectors, we've
  introduced a new abstraction that allows the caller to specify how they
  want the starting bytes of the packet to be filled out. By default, all
  callers will use the `randPacketFiller`, but may also pass in the
  `blankPacketFiller`, if they packet construction to be deterministic.

Fixes #42. 