### PR TITLE
sphinx: remove unused members of Router

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -88,8 +88,6 @@ func BenchmarkProcessPacket(b *testing.B) {
 		router := path[0]
 		router.log.Stop()
 		path[0] = &Router{
-			nodeID:   router.nodeID,
-			nodeAddr: router.nodeAddr,
 			onionKey: router.onionKey,
 			log:      NewMemoryReplayLog(),
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/chaincfg"
 	sphinx "github.com/lightningnetwork/lightning-onion"
 	"github.com/urfave/cli"
 )
@@ -300,7 +299,7 @@ func peel(ctx *cli.Context) error {
 
 	s := sphinx.NewRouter(
 		&sphinx.PrivKeyECDH{PrivKey: sessionKey},
-		&chaincfg.TestNet3Params, sphinx.NewMemoryReplayLog(),
+		sphinx.NewMemoryReplayLog(),
 	)
 	s.Start()
 	defer s.Stop()

--- a/path_test.go
+++ b/path_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,8 +148,7 @@ func TestOnionRouteBlinding(t *testing.T) {
 		blindingPoint *btcec.PublicKey) *ProcessedPacket {
 
 		r := NewRouter(
-			&PrivKeyECDH{PrivKey: key}, &chaincfg.MainNetParams,
-			NewMemoryReplayLog(),
+			&PrivKeyECDH{PrivKey: key}, NewMemoryReplayLog(),
 		)
 
 		require.NoError(t, r.Start())

--- a/sphinx.go
+++ b/sphinx.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcutil"
-	"github.com/btcsuite/btcd/chaincfg"
 )
 
 const (
@@ -484,26 +482,14 @@ type ProcessedPacket struct {
 // of processing incoming Sphinx onion packets thereby "peeling" a layer off
 // the onion encryption which the packet is wrapped with.
 type Router struct {
-	nodeID   [AddressSize]byte
-	nodeAddr *btcutil.AddressPubKeyHash
-
 	onionKey SingleKeyECDH
-
-	log ReplayLog
+	log      ReplayLog
 }
 
 // NewRouter creates a new instance of a Sphinx onion Router given the node's
 // currently advertised onion private key, and the target Bitcoin network.
-func NewRouter(nodeKey SingleKeyECDH, net *chaincfg.Params, log ReplayLog) *Router {
-	var nodeID [AddressSize]byte
-	copy(nodeID[:], btcutil.Hash160(nodeKey.PubKey().SerializeCompressed()))
-
-	// Safe to ignore the error here, nodeID is 20 bytes.
-	nodeAddr, _ := btcutil.NewAddressPubKeyHash(nodeID[:], net)
-
+func NewRouter(nodeKey SingleKeyECDH, log ReplayLog) *Router {
 	return &Router{
-		nodeID:   nodeID,
-		nodeAddr: nodeAddr,
 		onionKey: nodeKey,
 		log:      log,
 	}


### PR DESCRIPTION
By removing the unused members of the Router, we can remove the network parameter from NewRouter which will make it easier to instantiate the Router in other packages.

This will simplify the code for [route blinding receives](https://github.com/lightningnetwork/lnd/pull/8735) a bit simpler. 