### PR TITLE
sphinx: add OnionPublicKey method to Router

### DIFF
--- a/sphinx.go
+++ b/sphinx.go
@@ -627,6 +627,12 @@ func (r *Router) NextEphemeral(ephemPub *btcec.PublicKey) (*btcec.PublicKey,
 	return NextEphemeral(r.onionKey, ephemPub)
 }
 
+// OnionPublicKey returns the public key representing the onion key backing this
+// router.
+func (r *Router) OnionPublicKey() *btcec.PublicKey {
+	return r.onionKey.PubKey()
+}
+
 // unwrapPacket wraps a layer of the passed onion packet using the specified
 // shared secret and associated data. The associated data will be used to check
 // the HMAC at each hop to ensure the same data is passed along with the onion

--- a/sphinx_test.go
+++ b/sphinx_test.go
@@ -303,14 +303,14 @@ func TestSphinxNodeRelpaySameBatch(t *testing.T) {
 
 	// Allow the node to process the initial packet, this should proceed
 	// without any failures.
-	if err := tx.ProcessOnionPacket(0, fwdMsg, nil, 1, nil); err != nil {
+	if err := tx.ProcessOnionPacket(0, fwdMsg, nil, 1); err != nil {
 		t.Fatalf("unable to process sphinx packet: %v", err)
 	}
 
 	// Now, force the node to process the packet a second time, this call
 	// should not fail, even though the batch has internally recorded this
 	// as a duplicate.
-	err = tx.ProcessOnionPacket(1, fwdMsg, nil, 1, nil)
+	err = tx.ProcessOnionPacket(1, fwdMsg, nil, 1)
 	if err != nil {
 		t.Fatalf("adding duplicate sphinx packet to batch should not "+
 			"result in an error, instead got: %v", err)
@@ -349,7 +349,7 @@ func TestSphinxNodeRelpayLaterBatch(t *testing.T) {
 
 	// Allow the node to process the initial packet, this should proceed
 	// without any failures.
-	err = tx.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1, nil)
+	err = tx.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1)
 	if err != nil {
 		t.Fatalf("unable to process sphinx packet: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestSphinxNodeRelpayLaterBatch(t *testing.T) {
 
 	// Now, force the node to process the packet a second time, this should
 	// fail with a detected replay error.
-	err = tx2.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1, nil)
+	err = tx2.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1)
 	if err != nil {
 		t.Fatalf("sphinx packet replay should not have been rejected, "+
 			"instead error is %v", err)
@@ -395,7 +395,7 @@ func TestSphinxNodeReplayBatchIdempotency(t *testing.T) {
 
 	// Allow the node to process the initial packet, this should proceed
 	// without any failures.
-	err = tx.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1, nil)
+	err = tx.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1)
 	if err != nil {
 		t.Fatalf("unable to process sphinx packet: %v", err)
 	}
@@ -409,7 +409,7 @@ func TestSphinxNodeReplayBatchIdempotency(t *testing.T) {
 
 	// Now, force the node to process the packet a second time, this should
 	// not fail with a detected replay error.
-	err = tx2.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1, nil)
+	err = tx2.ProcessOnionPacket(uint16(0), fwdMsg, nil, 1)
 	if err != nil {
 		t.Fatalf("sphinx packet replay should not have been rejected, "+
 			"instead error is %v", err)


### PR DESCRIPTION
Expose the public key of the key that they router is backed by. We'll use this in LND  for route blinding to quickly be able to check if a dummy hop payload is destined for this node's router.